### PR TITLE
fix: buttons width and text align in small devices

### DIFF
--- a/src/components/aboutMe/AboutMe.module.css
+++ b/src/components/aboutMe/AboutMe.module.css
@@ -98,6 +98,7 @@
   .resume {
     width: 90%;
     font-size: 1rem;
+    text-align: justify;
   }
 
   .buttonsGroup {
@@ -105,10 +106,6 @@
     align-items: center;
   }
 
-  .contact,
-  .downloadCv {
-    width: 100%;
-  }
 }
 
 @media (min-width: 768px) and (max-width: 1023px) {

--- a/src/components/experience/Experience.module.css
+++ b/src/components/experience/Experience.module.css
@@ -82,6 +82,7 @@
 
   .experienceItemContent p {
     font-size: 0.95rem;
+    text-align: justify;
   }
 }
 


### PR DESCRIPTION
<img width="216" alt="Captura de Tela 2025-05-27 às 10 08 24" src="https://github.com/user-attachments/assets/1bd15009-da21-48d0-a2aa-14eac49eeee9" />

Fixed in about me section 

<img width="220" alt="Captura de Tela 2025-05-27 às 10 08 45" src="https://github.com/user-attachments/assets/498cad9e-2721-4ab3-b69c-1421b1c38962" />

Fixed in experiences section
